### PR TITLE
Add users id to note relationship

### DIFF
--- a/src/models/Note.php
+++ b/src/models/Note.php
@@ -79,6 +79,9 @@ class Note extends Model
     public function user()
     {
         return $this->belongsTo(config('chronicle.users_model'))
-            ->select(config('chronicle.users_table_name') . ' as name');
+                    ->select(
+                        config('chronicle.users_table_name') . ' as name',
+                        config('chronicle.users_table_id') . ' as id'
+                    );
     }
 }


### PR DESCRIPTION
Notes user can now be gotten if referenced from external libraries
(i.e. `Notes::where('section', 1)->with('user')`) 